### PR TITLE
Added UBX-RXM-RTCM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [3.5.*]
+- Added parsing of UBX-RXM-RTCM messages.
+
 ## [3.4.6] 2024-04-04
 - You can optionally include/exclude which generators to build by using the CMake options `-DINCLUDE_GENERATOR_*`. By default, RTCM and SPARTN generators are included and the old SPARTN generator is excluded.
 - Added support for control commands in the `example-lpp` when using `osr`, this was previously only available in when using `ssr`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [3.5.*]
+## [3.4.*]
 - Added parsing of UBX-RXM-RTCM messages.
 
 ## [3.4.6] 2024-04-04

--- a/receiver/ublox/CMakeLists.txt
+++ b/receiver/ublox/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(receiver_ublox STATIC
     "ubx_cfg_valset.cpp"
     "ubx_ack_ack.cpp"
     "ubx_ack_nak.cpp"
+    "ubx_rxm_rtcm.cpp"
 )
 add_library(receiver::ublox ALIAS receiver_ublox)
 

--- a/receiver/ublox/include/receiver/ublox/ubx_rxm_rtcm.hpp
+++ b/receiver/ublox/include/receiver/ublox/ubx_rxm_rtcm.hpp
@@ -1,0 +1,90 @@
+#pragma once
+#include <memory>
+#include <receiver/ublox/message.hpp>
+#include <string>
+#include <vector>
+
+namespace receiver {
+namespace ublox {
+
+namespace raw {
+struct RxmRtcm {
+    /* 0x00 */ uint8_t version;
+    union {
+        struct {
+            /* 0x01 */ struct {
+                /* bit 0 */ uint8_t   crc_failed;
+                /* bit 1-2 */ uint8_t msg_used;
+            } flags;
+            /* 0x02 */ uint16_t sub_type;
+            /* 0x04 */ uint16_t ref_station;
+            /* 0x06 */ uint16_t msg_type;
+        } v2;
+    } data;
+};
+}  // namespace raw
+
+class Decoder;
+class Encoder;
+class UbxRxmRtcm : public Message {
+public:
+    UBLOX_CONSTEXPR static uint8_t CLASS_ID   = 0x02;
+    UBLOX_CONSTEXPR static uint8_t MESSAGE_ID = 0x32;
+
+    UBLOX_EXPLICIT UbxRxmRtcm(raw::RxmRtcm payload) UBLOX_NOEXCEPT;
+    ~UbxRxmRtcm() override = default;
+
+    UbxRxmRtcm(UbxRxmRtcm const& other) : Message(other), mPayload(other.mPayload) {}
+    UbxRxmRtcm(UbxRxmRtcm&&)                 = delete;
+    UbxRxmRtcm& operator=(UbxRxmRtcm const&) = delete;
+    UbxRxmRtcm& operator=(UbxRxmRtcm&&)      = delete;
+
+    UBLOX_NODISCARD const raw::RxmRtcm& payload() const UBLOX_NOEXCEPT { return mPayload; }
+
+    UBLOX_NODISCARD uint8_t version() const UBLOX_NOEXCEPT { return mPayload.version; }
+    UBLOX_NODISCARD bool    crc_failed() const UBLOX_NOEXCEPT {
+        if (mPayload.version == 2) {
+            return mPayload.data.v2.flags.crc_failed;
+        } else {
+            return false;
+        }
+    }
+    UBLOX_NODISCARD uint8_t msg_used() const UBLOX_NOEXCEPT {
+        if (mPayload.version == 2) {
+            return mPayload.data.v2.flags.msg_used;
+        } else {
+            return 0;
+        }
+    }
+    UBLOX_NODISCARD uint16_t sub_type() const UBLOX_NOEXCEPT {
+        if (mPayload.version == 2) {
+            return mPayload.data.v2.sub_type;
+        } else {
+            return 0;
+        }
+    }
+    UBLOX_NODISCARD uint16_t ref_station() const UBLOX_NOEXCEPT {
+        if (mPayload.version == 2) {
+            return mPayload.data.v2.ref_station;
+        } else {
+            return 0;
+        }
+    }
+    UBLOX_NODISCARD uint16_t msg_type() const UBLOX_NOEXCEPT {
+        if (mPayload.version == 2) {
+            return mPayload.data.v2.msg_type;
+        } else {
+            return 0;
+        }
+    }
+
+    void print() const UBLOX_NOEXCEPT override;
+
+    UBLOX_NODISCARD static std::unique_ptr<Message> parse(Decoder& decoder) UBLOX_NOEXCEPT;
+
+private:
+    raw::RxmRtcm mPayload;
+};
+
+}  // namespace ublox
+}  // namespace receiver

--- a/receiver/ublox/parser.cpp
+++ b/receiver/ublox/parser.cpp
@@ -6,6 +6,7 @@
 #include "ubx_cfg_valget.hpp"
 #include "ubx_mon_ver.hpp"
 #include "ubx_nav_pvt.hpp"
+#include "ubx_rxm_rtcm.hpp"
 
 namespace receiver {
 namespace ublox {
@@ -115,6 +116,7 @@ std::unique_ptr<Message> Parser::try_parse() UBLOX_NOEXCEPT {
     case 0x068B: return UbxCfgValget::parse(decoder);
     case 0x0501: return UbxAckAck::parse(decoder);
     case 0x0500: return UbxAckNak::parse(decoder);
+    case 0x0232: return UbxRxmRtcm::parse(decoder);
     default: return std::unique_ptr<Message>{new UnsupportedMessage(message_class, message_id)};
     }
 }

--- a/receiver/ublox/ubx_rxm_rtcm.cpp
+++ b/receiver/ublox/ubx_rxm_rtcm.cpp
@@ -1,0 +1,69 @@
+#include "ubx_rxm_rtcm.hpp"
+
+#include <stdio.h>
+
+#include "decoder.hpp"
+#include "encoder.hpp"
+#include "parser.hpp"
+
+namespace receiver {
+namespace ublox {
+
+UbxRxmRtcm::UbxRxmRtcm(raw::RxmRtcm payload) UBLOX_NOEXCEPT : Message(CLASS_ID, MESSAGE_ID),
+                                                              mPayload(std::move(payload)) {}
+
+static char const* msg_used_str(uint8_t msg_used) UBLOX_NOEXCEPT {
+    switch (msg_used) {
+    case 0: return "DO NOT KNOW";
+    case 1: return "NOT USED";
+    case 2: return "USED";
+    default: return "?";
+    }
+}
+
+void UbxRxmRtcm::print() const UBLOX_NOEXCEPT {
+    if (mPayload.version == 2) {
+        printf("[%02X %02X] UBX-RXM-RTCM: %4u %s%s\n", message_class(), message_id(),
+               mPayload.data.v2.msg_type, msg_used_str(mPayload.data.v2.flags.msg_used),
+               mPayload.data.v2.flags.crc_failed ? " [CRC-FAILED]" : "");
+    } else {
+        printf("[%02X %02X] UBX-RXM-RTCM:\n", message_class(), message_id());
+        printf("[.....]    version: %u\n", mPayload.version);
+        printf("[.....]    (no data)\n");
+    }
+}
+
+std::unique_ptr<Message> UbxRxmRtcm::parse(Decoder& decoder) UBLOX_NOEXCEPT {
+    if (decoder.remaining() < 2) {
+        return nullptr;
+    }
+
+    auto version = decoder.U1();
+    if (decoder.error()) {
+        return nullptr;
+    }
+
+    raw::RxmRtcm payload;
+    if (version == 2) {
+        payload.version = version;
+
+        auto flags                       = decoder.U1();
+        payload.data.v2.flags.crc_failed = (flags >> 0) & 0x01;
+        payload.data.v2.flags.msg_used   = (flags >> 1) & 0x03;
+
+        payload.data.v2.sub_type    = decoder.U2();
+        payload.data.v2.ref_station = decoder.U2();
+        payload.data.v2.msg_type    = decoder.U2();
+    } else {
+        payload.version = version;
+    }
+
+    if (decoder.error()) {
+        return nullptr;
+    } else {
+        return std::unique_ptr<Message>{new UbxRxmRtcm(std::move(payload))};
+    }
+}
+
+}  // namespace ublox
+}  // namespace receiver


### PR DESCRIPTION
Added parsing of UBX-RXM-RTCM messages.

These can be useful do debug if the receiver is getting message and is using them.

Good:
```
[02 32] UBX-RXM-RTCM: 1075 USED
```

Bad:
```
[02 32] UBX-RXM-RTCM: 1075 NOT USED CRC-FAILED
```